### PR TITLE
#10 - added IAM Instance profile option for ec2

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Table of Contents
 
   * [Installation](#installation)
     * [Amazon Machine Image](#amazon-machine-image)
+    * [IAM Instance Profile](#iam-instance-profile)
     * [Security Groups](#security-groups)
     * [Subnets](#subnets)
   * [Building the code base](#building-the-code-base)
@@ -41,6 +42,13 @@ rm -rf /var/lib/go-agent/config/*
 ```
 Finally, create new [Amazon Machine Image](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html) from your instance. Each Elastic Agent Profile can use
 different AMI to suit your needs.
+
+### IAM Instance Profile
+
+AWS allows you to create an [IAM Instance Profile](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html) which
+assigns an AWS IAM role to the EC2 instance(s), which can be used to authorize the instances to invoke the AWS API. Provide the IAM Instance profile name
+(not the Role name, or the ARN) to launch instances with the corresponding role associated with them. There is no validation of the IAM Instance Profile
+and providing an invalid profile name will result in instances not being deployed.
 
 ### Security Groups
 

--- a/src/main/java/com/continuumsecurity/elasticagent/ec2/Ec2Instance.java
+++ b/src/main/java/com/continuumsecurity/elasticagent/ec2/Ec2Instance.java
@@ -171,6 +171,10 @@ public class Ec2Instance {
                         .tagSpecifications(tagSpecification)
                         .build();
 
+                if (request.properties().get("ec2_instance_profile") != null) {
+                    runInstancesRequest.setIamInstanceProfile(IamInstanceProfileSpecification.builder().arn(request.properties().get("ec2_instance_profile")).build());
+                }
+
                 response = ec2.runInstances(runInstancesRequest);
                 result = true;
 

--- a/src/main/java/com/continuumsecurity/elasticagent/ec2/Ec2Instance.java
+++ b/src/main/java/com/continuumsecurity/elasticagent/ec2/Ec2Instance.java
@@ -159,10 +159,7 @@ public class Ec2Instance {
                         .resourceType("instance")
                         .build();
 
-                String iamProfileName = "";
-                if (request.properties().get("ec2_instance_profile") != null) { 
-                  iamProfileName = request.properties().get("ec2_instance_profile");
-                }
+                String iamProfileName = (request.properties().get("ec2_instance_profile") == null) ? "" : request.properties().get("ec2_instance_profile");
                 
                 RunInstancesRequest runInstancesRequest = RunInstancesRequest.builder()
                         .imageId(request.properties().get("ec2_ami"))

--- a/src/main/java/com/continuumsecurity/elasticagent/ec2/Ec2Instance.java
+++ b/src/main/java/com/continuumsecurity/elasticagent/ec2/Ec2Instance.java
@@ -159,6 +159,11 @@ public class Ec2Instance {
                         .resourceType("instance")
                         .build();
 
+                String iamProfileName = "";
+                if (request.properties().get("ec2_instance_profile") != null) { 
+                  iamProfileName = request.properties().get("ec2_instance_profile");
+                }
+                
                 RunInstancesRequest runInstancesRequest = RunInstancesRequest.builder()
                         .imageId(request.properties().get("ec2_ami"))
                         .instanceType(InstanceType.fromValue(request.properties().get("ec2_instance_type")))
@@ -167,13 +172,10 @@ public class Ec2Instance {
                         .keyName(request.properties().get("ec2_key"))
                         .securityGroupIds(securityGroups)
                         .subnetId(subnets.get(i))
+                        .iamInstanceProfile(IamInstanceProfileSpecification.builder().name(iamProfileName).build())
                         .userData(Base64.getEncoder().encodeToString(userdata.getBytes()))
                         .tagSpecifications(tagSpecification)
                         .build();
-
-                if (request.properties().get("ec2_instance_profile") != null) {
-                    runInstancesRequest.setIamInstanceProfile(IamInstanceProfileSpecification.builder().arn(request.properties().get("ec2_instance_profile")).build());
-                }
 
                 response = ec2.runInstances(runInstancesRequest);
                 result = true;

--- a/src/main/java/com/continuumsecurity/elasticagent/ec2/executors/GetProfileMetadataExecutor.java
+++ b/src/main/java/com/continuumsecurity/elasticagent/ec2/executors/GetProfileMetadataExecutor.java
@@ -36,6 +36,7 @@ public class GetProfileMetadataExecutor implements RequestExecutor {
     private static final Metadata EC2_SUBNETS = new Metadata("ec2_subnets", true, false);
     private static final Metadata EC2_KEY = new Metadata("ec2_key", true, false);
     private static final Metadata EC2_USER_DATA = new Metadata("ec2_user_data", false, false);
+    private static final Metadata EC2_INSTANCE_PROFILE = new Metadata("ec2_instance_profile", false, false)
 
     static final List<Metadata> FIELDS = new ArrayList<>();
 
@@ -45,7 +46,9 @@ public class GetProfileMetadataExecutor implements RequestExecutor {
         FIELDS.add(EC2_SECURITY_GROUPS);
         FIELDS.add(EC2_SUBNETS);
         FIELDS.add(EC2_KEY);
-        FIELDS.add(EC2_USER_DATA);
+        FIELDS.add(EC2_USER_DATA;
+        FIELDS.add(EC2_INSTANCE_PROFILE);
+        );
     }
 
     @Override

--- a/src/main/java/com/continuumsecurity/elasticagent/ec2/executors/GetProfileMetadataExecutor.java
+++ b/src/main/java/com/continuumsecurity/elasticagent/ec2/executors/GetProfileMetadataExecutor.java
@@ -36,7 +36,7 @@ public class GetProfileMetadataExecutor implements RequestExecutor {
     private static final Metadata EC2_SUBNETS = new Metadata("ec2_subnets", true, false);
     private static final Metadata EC2_KEY = new Metadata("ec2_key", true, false);
     private static final Metadata EC2_USER_DATA = new Metadata("ec2_user_data", false, false);
-    private static final Metadata EC2_INSTANCE_PROFILE = new Metadata("ec2_instance_profile", false, false)
+    private static final Metadata EC2_INSTANCE_PROFILE = new Metadata("ec2_instance_profile", false, false);
 
     static final List<Metadata> FIELDS = new ArrayList<>();
 
@@ -46,9 +46,8 @@ public class GetProfileMetadataExecutor implements RequestExecutor {
         FIELDS.add(EC2_SECURITY_GROUPS);
         FIELDS.add(EC2_SUBNETS);
         FIELDS.add(EC2_KEY);
-        FIELDS.add(EC2_USER_DATA;
+        FIELDS.add(EC2_USER_DATA);
         FIELDS.add(EC2_INSTANCE_PROFILE);
-        );
     }
 
     @Override

--- a/src/main/resources/profile.template.html
+++ b/src/main/resources/profile.template.html
@@ -53,9 +53,18 @@
     </div>
 
     <div class="columns medium-4 large-3">
+        <label ng-class="{'is-invalid-label': GOINPUTNAME[ec2_instance_profile].$error.server}">IAM Instance Profile ARN:</label>
+        <input ng-class="{'is-invalid-input': GOINPUTNAME[ec2_instance_profile].$error.server}" type="text" ng-model="ec2_instance_profile" ng-required="false"/>
+        <span class="form_error form-error" ng-class="{'is-visible': GOINPUTNAME[ec2_instance_profile].$error.server}"
+              ng-show="GOINPUTNAME[ec2_instance_profile].$error.server">{{GOINPUTNAME[ec2_instance_profile].$error.server}}</span>
+    </div>
+
+    <div class="columns medium-4 large-3">
         <label ng-class="{'is-invalid-label': GOINPUTNAME[ec2_user_data].$error.server}">User data:</label>
         <textarea ng-class="{'is-invalid-input': GOINPUTNAME[ec2_user_data].$error.server}" type="text" rows="3" ng-model="ec2_user_data" ng-required="false"/>
         <span class="form_error form-error" ng-class="{'is-visible': GOINPUTNAME[ec2_user_data].$error.server}"
               ng-show="GOINPUTNAME[ec2_user_data].$error.server">{{GOINPUTNAME[ec2_user_data].$error.server}}</span>
     </div>
+
+
 </div>

--- a/src/test/java/com/continuumsecurity/elasticagent/ec2/BaseTest.java
+++ b/src/test/java/com/continuumsecurity/elasticagent/ec2/BaseTest.java
@@ -46,6 +46,7 @@ public abstract class BaseTest {
         properties.put("ec2_subnets", Properties.SUBNETS);
         properties.put("ec2_key", Properties.KEY);
         properties.put("ec2_user_data", Properties.USERDATA);
+        properties.put("ec2_instance_profile", Properties.INSTANCE_PROFILE)
         return properties;
     }
 }

--- a/src/test/java/com/continuumsecurity/elasticagent/ec2/Properties.java
+++ b/src/test/java/com/continuumsecurity/elasticagent/ec2/Properties.java
@@ -12,7 +12,7 @@ public interface Properties {
     String SG_IDS = "sg-IDS";
     String TYPE = "t3.nano";
     String USERDATA = "#!/bin/bash\n" + "echo hi";
-    String INSTANCE_PROFILE = "arn:aws:iam::000000:instance-profile/InstanceProfile"
+    String INSTANCE_PROFILE = "InstanceProfileName"
     String AUTO_REGISTER_TIMEOUT = "5";
     String MAX_ELASTIC_AGENTS = "50";
     String AUTO_REGISTER_KEY = "AUTO_REGISTER_KEY";

--- a/src/test/java/com/continuumsecurity/elasticagent/ec2/Properties.java
+++ b/src/test/java/com/continuumsecurity/elasticagent/ec2/Properties.java
@@ -12,6 +12,7 @@ public interface Properties {
     String SG_IDS = "sg-IDS";
     String TYPE = "t3.nano";
     String USERDATA = "#!/bin/bash\n" + "echo hi";
+    String INSTANCE_PROFILE = "arn:aws:iam::000000:instance-profile/InstanceProfile"
     String AUTO_REGISTER_TIMEOUT = "5";
     String MAX_ELASTIC_AGENTS = "50";
     String AUTO_REGISTER_KEY = "AUTO_REGISTER_KEY";

--- a/src/test/java/com/continuumsecurity/elasticagent/ec2/Test.java
+++ b/src/test/java/com/continuumsecurity/elasticagent/ec2/Test.java
@@ -28,6 +28,7 @@ public class Test {
         properties.put("ec2_subnets", Properties.SUBNETS);
         properties.put("ec2_key", Properties.KEY);
         properties.put("ec2_user_data", Properties.USERDATA);
+        properties.put("ec2_instance_profile", Properties.INSTANCE_TYPE);
 
 
         JobIdentifier jobIdentifier = new JobIdentifier(

--- a/src/test/java/com/continuumsecurity/elasticagent/ec2/Test.java
+++ b/src/test/java/com/continuumsecurity/elasticagent/ec2/Test.java
@@ -28,7 +28,7 @@ public class Test {
         properties.put("ec2_subnets", Properties.SUBNETS);
         properties.put("ec2_key", Properties.KEY);
         properties.put("ec2_user_data", Properties.USERDATA);
-        properties.put("ec2_instance_profile", Properties.INSTANCE_TYPE);
+        properties.put("ec2_instance_profile", Properties.INSTANCE_PROFILE);
 
 
         JobIdentifier jobIdentifier = new JobIdentifier(

--- a/src/test/java/com/continuumsecurity/elasticagent/ec2/executors/GetProfileMetadataExecutorTest.java
+++ b/src/test/java/com/continuumsecurity/elasticagent/ec2/executors/GetProfileMetadataExecutorTest.java
@@ -80,6 +80,13 @@ public class GetProfileMetadataExecutorTest {
                 "    }\n" +
                 "  },\n" +
                 "  {\n" +
+                "    \"key\": \"ec2_instance_profile\",\n" +
+                "    \"metadata\": {\n" +
+                "      \"required\": false,\n" +
+                "      \"secure\": false\n" +
+                "    }\n" +
+                "  },\n" +
+                "  {\n" +
                 "    \"key\": \"ec2_user_data\",\n" +
                 "    \"metadata\": {\n" +
                 "      \"required\": false,\n" +


### PR DESCRIPTION
IAM Instance Profile can be provided when creating / editing the Elastic Agent profile now.

* Some notes: Leaving the field blank will not use an IAM profile.
* The IAM Profile Name must be used from IAM (not the Role name). 

Resolves #10 

Tested successfully on GoCD 19.10.