### PR TITLE
Add support for default credentials provider chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Table of Contents
     * [Amazon Machine Image](#amazon-machine-image)
     * [Security Groups](#security-groups)
     * [Subnets](#subnets)
+    * [AWS Authentication](#aws-authentication)                            
   * [Building the code base](#building-the-code-base)
   * [Credits](#credits)
   * [Disclaimer](#disclaimer)
@@ -57,6 +58,12 @@ subnets (ideally in different availability zones) in the elastic agent profile a
 instance. If the chosen availability zone has run out of your requested instance type, the plugin will try to bring up instance in the next subnet.
 
 Also, remember to enable auto-assign public IP address to the subnets.
+
+### AWS Authentication
+
+If an AWS Access Key ID and AWS Secret Access Key is provided for a cluster profile, then those credentials will be used. Otherwise, if left blank,
+the [Default Provider Credential Chain](https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/credentials.html) will be used. i.e. The default provider
+credentials will be resolved from the GoCD server environment (e.g. ~/.credentials file or Ec2 IAM Instance profiles from instance metadata).
 
 ## Building the code base
 

--- a/src/main/java/com/continuumsecurity/elasticagent/ec2/Ec2AgentInstances.java
+++ b/src/main/java/com/continuumsecurity/elasticagent/ec2/Ec2AgentInstances.java
@@ -25,8 +25,6 @@ import com.continuumsecurity.elasticagent.ec2.models.StatusReport;
 import com.continuumsecurity.elasticagent.ec2.requests.CreateAgentRequest;
 import org.apache.commons.lang3.StringUtils;
 import org.joda.time.Period;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.ec2.model.*;
 
@@ -158,15 +156,12 @@ public class Ec2AgentInstances implements AgentInstances<Ec2Instance> {
     @Override
     public void refreshAll(ClusterProfileProperties clusterProfileProperties) throws Exception {
         if (!refreshed) {
-            AwsBasicCredentials awsCredentials = AwsBasicCredentials.create(
-                    clusterProfileProperties.getAwsAccessKeyId(),
-                    clusterProfileProperties.getAwsSecretAccessKey()
-            );
-
-            Ec2Client ec2 = Ec2Client.builder()
-                    .region(clusterProfileProperties.getAwsRegion())
-                    .credentialsProvider(StaticCredentialsProvider.create(awsCredentials))
-                    .build();
+    
+            Ec2Client ec2 = Ec2Instance.createEc2Client(
+                               clusterProfileProperties.getAwsAccessKeyId(),
+                               clusterProfileProperties.getAwsSecretAccessKey(),
+                               clusterProfileProperties.getAwsRegion()
+                            );
 
             DescribeInstancesResponse response = ec2.describeInstances(
                     DescribeInstancesRequest.builder()
@@ -220,15 +215,11 @@ public class Ec2AgentInstances implements AgentInstances<Ec2Instance> {
 
     @Override
     public StatusReport getStatusReport(ClusterProfileProperties clusterProfileProperties) throws Exception {
-        AwsBasicCredentials awsCredentials = AwsBasicCredentials.create(
-                clusterProfileProperties.getAwsAccessKeyId(),
-                clusterProfileProperties.getAwsSecretAccessKey()
-        );
-
-        Ec2Client ec2 = Ec2Client.builder()
-                .region(clusterProfileProperties.getAwsRegion())
-                .credentialsProvider(StaticCredentialsProvider.create(awsCredentials))
-                .build();
+            Ec2Client ec2 = Ec2Instance.createEc2Client(
+                               clusterProfileProperties.getAwsAccessKeyId(),
+                               clusterProfileProperties.getAwsSecretAccessKey(),
+                               clusterProfileProperties.getAwsRegion()
+                            );
 
         DescribeInstancesResponse response = ec2.describeInstances(
                 DescribeInstancesRequest.builder()
@@ -277,15 +268,12 @@ public class Ec2AgentInstances implements AgentInstances<Ec2Instance> {
 
     @Override
     public AgentStatusReport getAgentStatusReport(ClusterProfileProperties clusterProfileProperties, Ec2Instance agentInstance) {
-        AwsBasicCredentials awsCredentials = AwsBasicCredentials.create(
-                clusterProfileProperties.getAwsAccessKeyId(),
-                clusterProfileProperties.getAwsSecretAccessKey()
-        );
+            Ec2Client ec2 = Ec2Instance.createEc2Client(
+                               clusterProfileProperties.getAwsAccessKeyId(),
+                               clusterProfileProperties.getAwsSecretAccessKey(),
+                               clusterProfileProperties.getAwsRegion()
+                            );
 
-        Ec2Client ec2 = Ec2Client.builder()
-                .region(clusterProfileProperties.getAwsRegion())
-                .credentialsProvider(StaticCredentialsProvider.create(awsCredentials))
-                .build();
 
         DescribeInstancesResponse response = ec2.describeInstances(
                 DescribeInstancesRequest.builder()

--- a/src/main/java/com/continuumsecurity/elasticagent/ec2/Ec2Instance.java
+++ b/src/main/java/com/continuumsecurity/elasticagent/ec2/Ec2Instance.java
@@ -219,10 +219,13 @@ public class Ec2Instance {
             ec2.close();
         }
     }
-
+    
+    private static boolean isNotNullOrBlank(String testString) {
+    	return testString!=null && !testString.isBlank();
+    }
     
     private static AwsCredentialsProvider getCredentialsProvider(String awsAccessKeyId, String awsSecretAccessKey) {
-        if (awsAccessKeyId != null && awsSecretAccessKey != null) {
+        if (isNotNullOrBlank(awsAccessKeyId) && isNotNullOrBlank(awsSecretAccessKey)) {
             AwsBasicCredentials awsCredentials = AwsBasicCredentials.create(awsAccessKeyId,awsSecretAccessKey);
             return StaticCredentialsProvider.create(awsCredentials);
         }

--- a/src/main/java/com/continuumsecurity/elasticagent/ec2/Ec2Instance.java
+++ b/src/main/java/com/continuumsecurity/elasticagent/ec2/Ec2Instance.java
@@ -21,8 +21,7 @@ package com.continuumsecurity.elasticagent.ec2;
 import com.continuumsecurity.elasticagent.ec2.models.JobIdentifier;
 import com.continuumsecurity.elasticagent.ec2.requests.CreateAgentRequest;
 import org.joda.time.DateTime;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.*;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.regions.Region;
@@ -221,12 +220,20 @@ public class Ec2Instance {
         }
     }
 
-    private static Ec2Client createEc2Client(String awsAccessKeyId, String awsSecretAccessKey, Region region) {
-        AwsBasicCredentials awsCredentials = AwsBasicCredentials.create(awsAccessKeyId, awsSecretAccessKey);
-
+    
+    private static AwsCredentialsProvider getCredentialsProvider(String awsAccessKeyId, String awsSecretAccessKey) {
+        if (awsAccessKeyId != null && awsSecretAccessKey != null) {
+            AwsBasicCredentials awsCredentials = AwsBasicCredentials.create(awsAccessKeyId,awsSecretAccessKey);
+            return StaticCredentialsProvider.create(awsCredentials);
+        }
+        else {
+            return DefaultCredentialsProvider.create();
+        }
+    }
+    protected static Ec2Client createEc2Client(String awsAccessKeyId, String awsSecretAccessKey, Region region) {
         return Ec2Client.builder()
                 .region(region)
-                .credentialsProvider(StaticCredentialsProvider.create(awsCredentials))
+                .credentialsProvider(getCredentialsProvider(awsAccessKeyId,awsSecretAccessKey))
                 .build();
     }
 

--- a/src/main/java/com/continuumsecurity/elasticagent/ec2/PluginSettings.java
+++ b/src/main/java/com/continuumsecurity/elasticagent/ec2/PluginSettings.java
@@ -100,8 +100,8 @@ public class PluginSettings {
                 "goServerUrl='" + goServerUrl + '\'' +
                 ", autoRegisterTimeout='" + autoRegisterTimeout + '\'' +
                 ", maxElasticAgents='" + maxElasticAgents + '\'';
-        if (awsAccessKeyId != null) pluginSettingsString += ", awsAccessKeyId='" + awsAccessKeyId + '\'';
-        if (awsSecretAccessKey != null) pluginSettingsString += ", awsSecretAccessKey='" + awsSecretAccessKey + '\'';
+        if (awsAccessKeyId != null && !awsAccessKeyId.isBlank()) pluginSettingsString += ", awsAccessKeyId='" + awsAccessKeyId + '\'';
+        if (awsSecretAccessKey != null && !awsSecretAccessKey.isBlank()) pluginSettingsString += ", awsSecretAccessKey='" + awsSecretAccessKey + '\'';
         pluginSettingsString += ", awsRegion='" + awsRegion + '\'' +
                 ", autoRegisterPeriod=" + autoRegisterPeriod +
                 '}';

--- a/src/main/java/com/continuumsecurity/elasticagent/ec2/PluginSettings.java
+++ b/src/main/java/com/continuumsecurity/elasticagent/ec2/PluginSettings.java
@@ -96,15 +96,17 @@ public class PluginSettings {
 
     @Override
     public String toString() {
-        return "PluginSettings{" +
+        String pluginSettingsString = "PluginSettings{" +
                 "goServerUrl='" + goServerUrl + '\'' +
                 ", autoRegisterTimeout='" + autoRegisterTimeout + '\'' +
-                ", maxElasticAgents='" + maxElasticAgents + '\'' +
-                ", awsAccessKeyId='" + awsAccessKeyId + '\'' +
-                ", awsSecretAccessKey='" + awsSecretAccessKey + '\'' +
-                ", awsRegion='" + awsRegion + '\'' +
+                ", maxElasticAgents='" + maxElasticAgents + '\'';
+        if (awsAccessKeyId != null) pluginSettingsString += ", awsAccessKeyId='" + awsAccessKeyId + '\'';
+        if (awsSecretAccessKey != null) pluginSettingsString += ", awsSecretAccessKey='" + awsSecretAccessKey + '\'';
+        pluginSettingsString += ", awsRegion='" + awsRegion + '\'' +
                 ", autoRegisterPeriod=" + autoRegisterPeriod +
                 '}';
+        
+        return pluginSettingsString;
     }
 
     public Period getAutoRegisterPeriod() {

--- a/src/main/java/com/continuumsecurity/elasticagent/ec2/executors/GetClusterProfileMetadataExecutor.java
+++ b/src/main/java/com/continuumsecurity/elasticagent/ec2/executors/GetClusterProfileMetadataExecutor.java
@@ -32,8 +32,8 @@ public class GetClusterProfileMetadataExecutor implements RequestExecutor {
     public static final Metadata GO_SERVER_URL = new GoServerURLMetadata();
     public static final Metadata AUTO_REGISTER_TIMEOUT = new NumberMetadata("auto_register_timeout", true);
     public static final Metadata MAX_ELASTIC_AGENTS = new NumberMetadata("max_elastic_agents", true);
-    public static final Metadata AWS_ACCESS_KEY_ID = new Metadata("aws_access_key_id", true, false);
-    public static final Metadata AWS_SECRET_ACCESS_KEY = new Metadata("aws_secret_access_key", true, true);
+    public static final Metadata AWS_ACCESS_KEY_ID = new Metadata("aws_access_key_id", false, false);
+    public static final Metadata AWS_SECRET_ACCESS_KEY = new Metadata("aws_secret_access_key", false, true);
     public static final Metadata AWS_REGION = new Metadata("aws_region", true, false);
 
     public static final List<Metadata> CLUSTER_PROFILE_FIELDS = new ArrayList<>();

--- a/src/main/resources/cluster-profile.template.html
+++ b/src/main/resources/cluster-profile.template.html
@@ -59,16 +59,16 @@ Ensure that the keys you use are also declared in the GetPluginConfigurationExec
     </fieldset>
 
     <fieldset>
-        <legend>AWS account configuration</legend>
+        <legend>AWS account configuration (Setting Key ID / Secret here will override default provider chain)</legend>
         <div class="form_item_block">
-            <label>AWS access key ID:<span class='asterix'>*</span></label>
-            <input type="text" ng-model="aws_access_key_id" ng-required="true"/>
+            <label>AWS access key ID:</label>
+            <input type="text" ng-model="aws_access_key_id" ng-required="false"/>
             <span class="form_error" ng-show="GOINPUTNAME[aws_access_key_id].$error.server">{{GOINPUTNAME[aws_access_key_id].$error.server}}</span>
         </div>
 
         <div class="form_item_block">
-            <label>AWS secret access key:<span class='asterix'>*</span></label>
-            <input type="password" ng-model="aws_secret_access_key" ng-required="true"/>
+            <label>AWS secret access key:</label>
+            <input type="password" ng-model="aws_secret_access_key" ng-required="false"/>
             <span class="form_error" ng-show="GOINPUTNAME[aws_secret_access_key].$error.server">{{GOINPUTNAME[aws_secret_access_key].$error.server}}</span>
         </div>
 

--- a/src/test/java/com/continuumsecurity/elasticagent/ec2/PluginSettingsTest.java
+++ b/src/test/java/com/continuumsecurity/elasticagent/ec2/PluginSettingsTest.java
@@ -22,6 +22,9 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.not;
 
 public class PluginSettingsTest {
     @Test
@@ -35,5 +38,28 @@ public class PluginSettingsTest {
         assertThat(pluginSettings.getGoServerUrl(), is("https://example.com/go"));
         assertThat(pluginSettings.getAwsAccessKeyId(), is("123456"));
         assertThat(pluginSettings.getAwsSecretAccessKey(), is("7890"));
+    }
+    
+    @Test
+    public void shouldDeserializeFromJSONWithNullCredentials() throws Exception {
+        PluginSettings pluginSettings = PluginSettings.fromJSON("{" +
+                "\"go_server_url\": \"https://example.com/go\"" +
+                "}");
+        
+        assertThat(pluginSettings.getGoServerUrl(), is("https://example.com/go"));
+        assertThat(pluginSettings.getAwsAccessKeyId(), is(nullValue()));
+        assertThat(pluginSettings.getAwsSecretAccessKey(), is(nullValue()));
+    }
+    
+    @Test
+    public void shouldSerializeProvidedCredentialsOnly() throws Exception {
+      PluginSettings pluginSettings = PluginSettings.fromJSON("{" +
+                "\"go_server_url\": \"https://example.com/go\", " +
+                "\"aws_access_key_id\": \"123456\"" +
+                "}");
+
+        assertThat(pluginSettings.toString(), containsString("awsAccessKeyId"));
+        assertThat(pluginSettings.toString(), containsString("123456"));
+        assertThat(pluginSettings.toString(), not(containsString("awsSecretAccessKey")));
     }
 }

--- a/src/test/java/com/continuumsecurity/elasticagent/ec2/executors/ClusterProfileValidateRequestExecutorTest.java
+++ b/src/test/java/com/continuumsecurity/elasticagent/ec2/executors/ClusterProfileValidateRequestExecutorTest.java
@@ -34,8 +34,6 @@ public class ClusterProfileValidateRequestExecutorTest {
                 "{\"message\":\"Go Server URL must not be blank.\",\"key\":\"go_server_url\"}," +
                 "{\"message\":\"auto_register_timeout must be a positive integer.\",\"key\":\"auto_register_timeout\"}," +
                 "{\"message\":\"max_elastic_agents must be a positive integer.\",\"key\":\"max_elastic_agents\"}," +
-                "{\"message\":\"aws_access_key_id must not be blank.\",\"key\":\"aws_access_key_id\"}," +
-                "{\"message\":\"aws_secret_access_key must not be blank.\",\"key\":\"aws_secret_access_key\"}," +
                 "{\"message\":\"aws_region must not be blank.\",\"key\":\"aws_region\"}," +
                 "{\"key\":\"foo\",\"message\":\"Is an unknown property\"}" +
                 "]";
@@ -51,8 +49,6 @@ public class ClusterProfileValidateRequestExecutorTest {
                 "{\"message\":\"Go Server URL must not be blank.\",\"key\":\"go_server_url\"}," +
                 "{\"message\":\"auto_register_timeout must be a positive integer.\",\"key\":\"auto_register_timeout\"}," +
                 "{\"message\":\"max_elastic_agents must be a positive integer.\",\"key\":\"max_elastic_agents\"}," +
-                "{\"message\":\"aws_access_key_id must not be blank.\",\"key\":\"aws_access_key_id\"}," +
-                "{\"message\":\"aws_secret_access_key must not be blank.\",\"key\":\"aws_secret_access_key\"}," +
                 "{\"message\":\"aws_region must not be blank.\",\"key\":\"aws_region\"}" +
                 "]\n";
 

--- a/src/test/java/com/continuumsecurity/elasticagent/ec2/executors/GetClusterProfileMetadataExecutorTest.java
+++ b/src/test/java/com/continuumsecurity/elasticagent/ec2/executors/GetClusterProfileMetadataExecutorTest.java
@@ -63,11 +63,11 @@ public class GetClusterProfileMetadataExecutorTest {
                 "}," +
                 "{" +
                 "\"key\":\"aws_access_key_id\"," +
-                "\"metadata\":{\"required\":true,\"secure\":false}" +
+                "\"metadata\":{\"required\":false,\"secure\":false}" +
                 "}," +
                 "{" +
                 "\"key\":\"aws_secret_access_key\"," +
-                "\"metadata\":{\"required\":true,\"secure\":true}" +
+                "\"metadata\":{\"required\":false,\"secure\":true}" +
                 "}," +
                 "{" +
                 "\"key\":\"aws_region\"," +


### PR DESCRIPTION
The AWS default credentials provider chain will try to resolve credentials from default locations (IAM instance profiles, files, environment variables, etc). This makes providing credentials directly in the plugin optional.

Resolves #12 