### PR TITLE
DE-174: Check if instance is IMSDv1 or IMSDv2 to get ec2 metadata

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ plugins {
 }
 
 group 'com.continuumsecurity.elasticagent'
-version '2.2.1'
+version '2.2.2'
 
 // these values that go into plugin.xml
 project.ext.pluginDesc = [

--- a/src/main/java/com/continuumsecurity/elasticagent/ec2/Ec2Instance.java
+++ b/src/main/java/com/continuumsecurity/elasticagent/ec2/Ec2Instance.java
@@ -76,8 +76,18 @@ public class Ec2Instance {
                 "echo \"wrapper.app.parameter.103=NONE\" >> /usr/share/go-agent/wrapper-config/wrapper-properties.conf\n" +
                 "mkdir -p /var/lib/go-agent/config\n" +
                 "echo \"agent.auto.register.key=" + request.autoRegisterKey() + "\" > /var/lib/go-agent/config/autoregister.properties\n" +
-                "echo \"agent.auto.register.hostname=EA_$(curl http://169.254.169.254/latest/meta-data/instance-id)\" >> /var/lib/go-agent/config/autoregister.properties\n" +
-                "echo \"agent.auto.register.elasticAgent.agentId=$(curl http://169.254.169.254/latest/meta-data/instance-id)\" >> /var/lib/go-agent/config/autoregister.properties\n" +
+
+                "HTTP_CODE=`curl -I http://169.254.169.254 | head -n 1 | cut -d$' ' -f2`\n" +
+                "if [[ HTTP_CODE -eq 200 ]];\n" +
+                "then\n" +
+                "INSTANCE_ID=`curl http://169.254.169.254/latest/meta-data/instance-id`\n" +
+                "else\n" +
+                "TOKEN=`curl -X PUT 'http://169.254.169.254/latest/api/token' -H 'X-aws-ec2-metadata-token-ttl-seconds: 21600'`\n" +
+                "INSTANCE_ID=`curl -H \"X-aws-ec2-metadata-token: $TOKEN\" http://169.254.169.254/latest/meta-data/instance-id`\n" +
+                "fi\n" +
+
+                "echo \"agent.auto.register.hostname=EA_$INSTANCE_ID\" >> /var/lib/go-agent/config/autoregister.properties\n" +
+                "echo \"agent.auto.register.elasticAgent.agentId=$INSTANCE_ID\" >> /var/lib/go-agent/config/autoregister.properties\n" +
                 "echo \"agent.auto.register.elasticAgent.pluginId=" + Constants.PLUGIN_ID + "\" >> /var/lib/go-agent/config/autoregister.properties\n" +
                 "chown -R go:go /var/log/go-agent/\n" +
                 "chown -R go:go /var/lib/go-agent/\n" +


### PR DESCRIPTION
Check http code response from http://169.254.169.254 to know if we are on an instance with IMSDv1 or IMSDv2. If it responds with 200, we are in an IMSDv1 and we can get the ec2 metadata without a token, otherwise, we need to get the token first and then get ec2 metadata info